### PR TITLE
Chaos Labs Risk Parameter Updates - Increase Debt Ceiling for SNX and MKR on V3 Ethereum - 01.31.2024

### DIFF
--- a/diffs/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211_before_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211_after.md
+++ b/diffs/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211_before_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211_after.md
@@ -1,0 +1,38 @@
+## Reserve changes
+
+### Reserve altered
+
+#### MKR ([0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2](https://etherscan.io/address/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2))
+
+| description | value before | value after |
+| --- | --- | --- |
+| debtCeiling | 8,500,000 $ | 12,000,000 $ |
+
+
+#### SNX ([0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F](https://etherscan.io/address/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F))
+
+| description | value before | value after |
+| --- | --- | --- |
+| debtCeiling | 2,500,000 $ | 4,000,000 $ |
+
+
+## Raw diff
+
+```json
+{
+  "reserves": {
+    "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2": {
+      "debtCeiling": {
+        "from": 850000000,
+        "to": 1200000000
+      }
+    },
+    "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F": {
+      "debtCeiling": {
+        "from": 250000000,
+        "to": 400000000
+      }
+    }
+  }
+}
+```

--- a/src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211.sol
+++ b/src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV3PayloadEthereum} from 'aave-helpers/v3-config-engine/AaveV3PayloadEthereum.sol';
+import {EngineFlags} from 'aave-helpers/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-helpers/v3-config-engine/IAaveV3ConfigEngine.sol';
+
+/**
+ * @title Chaos Labs Risk Parameter Updates - Increase Debt Ceiling for SNX and MKR on V3 Ethereum - 01.31.2024
+ * @author Chaos Labs
+ * - Snapshot: https://snapshot.org/#/aave.eth/proposal/0xe1a36b7daaf5ab8555510edf53fc75645c7a0ac26b3d47cfe9295b94f96bcf3a
+ * - Discussion: https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-debt-ceiling-for-snx-and-mkr-on-v3-ethereum-01-31-2024/16480/1
+ */
+contract AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211 is
+  AaveV3PayloadEthereum
+{
+  function collateralsUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.CollateralUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.CollateralUpdate[]
+      memory collateralUpdate = new IAaveV3ConfigEngine.CollateralUpdate[](2);
+
+    collateralUpdate[0] = IAaveV3ConfigEngine.CollateralUpdate({
+      asset: AaveV3EthereumAssets.MKR_UNDERLYING,
+      ltv: EngineFlags.KEEP_CURRENT,
+      liqThreshold: EngineFlags.KEEP_CURRENT,
+      liqBonus: EngineFlags.KEEP_CURRENT,
+      debtCeiling: 12_000_000,
+      liqProtocolFee: EngineFlags.KEEP_CURRENT
+    });
+    collateralUpdate[1] = IAaveV3ConfigEngine.CollateralUpdate({
+      asset: AaveV3EthereumAssets.SNX_UNDERLYING,
+      ltv: EngineFlags.KEEP_CURRENT,
+      liqThreshold: EngineFlags.KEEP_CURRENT,
+      liqBonus: EngineFlags.KEEP_CURRENT,
+      debtCeiling: 4_000_000,
+      liqProtocolFee: EngineFlags.KEEP_CURRENT
+    });
+
+    return collateralUpdate;
+  }
+}

--- a/src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211.t.sol
+++ b/src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/ProtocolV3TestBase.sol';
+import {AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211} from './AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211.sol';
+
+/**
+ * @dev Test for AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211
+ * command: make test-contract filter=AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211
+ */
+contract AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211_Test is
+  ProtocolV3TestBase
+{
+  AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211
+    internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 19204803);
+    proposal = new AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    (ReserveConfig[] memory allConfigsBefore, ReserveConfig[] memory allConfigsAfter) = defaultTest(
+      'AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211',
+      AaveV3Ethereum.POOL,
+      address(proposal)
+    );
+
+    address[] memory assetsChanged = new address[](2);
+    assetsChanged[0] = AaveV3EthereumAssets.MKR_UNDERLYING;
+    assetsChanged[1] = AaveV3EthereumAssets.SNX_UNDERLYING;
+    _noReservesConfigsChangesApartFrom(allConfigsBefore, allConfigsAfter, assetsChanged);
+
+    ReserveConfig memory mkrConfigAfter = _findReserveConfig(
+      allConfigsAfter,
+      AaveV3EthereumAssets.MKR_UNDERLYING
+    );
+    mkrConfigAfter.debtCeiling = 12_000_000_00;
+    _validateReserveConfig(mkrConfigAfter, allConfigsAfter);
+
+    ReserveConfig memory snxConfigAfter = _findReserveConfig(allConfigsAfter, assetsChanged[1]);
+    snxConfigAfter.debtCeiling = 4_000_000_00;
+    _validateReserveConfig(snxConfigAfter, allConfigsAfter);
+  }
+}

--- a/src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024.md
+++ b/src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024.md
@@ -1,0 +1,57 @@
+---
+title: "Chaos Labs Risk Parameter Updates - Increase Debt Ceiling for SNX and MKR on V3 Ethereum - 01.31.2024"
+author: "Chaos Labs"
+discussions: "https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-debt-ceiling-for-snx-and-mkr-on-v3-ethereum-01-31-2024/16480/1"
+snapshot: "https://snapshot.org/#/aave.eth/proposal/0xe1a36b7daaf5ab8555510edf53fc75645c7a0ac26b3d47cfe9295b94f96bcf3a"
+---
+
+## Simple Summary
+
+A proposal to increase the debt ceiling of SNX and MKR on V3 Ethereum
+
+## Motivation
+
+SNX
+The current debt ceiling for SNX on V3 Ethereum set at $2.5M, has reached 94% utilization.
+
+Given current market conditions our Isolation Mode Methodology 1 supports increasing the debt ceiling to $4M.
+
+It is important to note that the majority of SNX debt positions are concentrated within two accounts, accounting for over 90% of the total debt, as outlined below. While this concentration does not affect the current recommendation, it is something to continue monitoring and will be considered in future recommendations and cases of significant market changes.
+
+Positions Analysis
+There are currently two major users utilizing SNX as collateral on V3 Ethereum:
+
+1. 0x09d86d566092bec46d449e72087ee788937599d2 1 - borrowing $1.81M in stables (USDC and USDT) against his 1.4M SNX collateral, accounting for nearly 73% of the debt ceiling. The user’s current health score is 1.59.
+2. 0x97cfb214adcd7243efd6b491a6c719c493d04122 - borrowing ~$448K USDT against his ~595K SNX collateral, accounting for nearly 18% of the debt ceiling. The user’s current health score is 2.73.
+
+MKR
+The current debt ceiling for MKR on V3 Ethereum set at $8.5M, has reached 99% utilization.
+
+Given current market conditions our Isolation Mode Methodology 1 supports increasing the debt ceiling to $12M.
+
+There are currently four major users using MKR as collateral on V3 Ethereum, utilizing 87.5% of the debt ceiling. While this concentration does not affect the current recommendation, it is something to continue monitoring and will be considered in future recommendations and cases of significant market changes
+
+Positions Analysis
+
+1. 0xa9dee54892713f43c221509cfedbd717d16791a0 - borrowing ~$3.79 DAI against his ~6,27K MKR collateral, accounting for nearly 45% of the debt ceiling. The user’s current health score is 2.27.
+2. 0x09eda5af6b634dcee8e4c563a97a18dde1a11c81 - borrowing ~$2.11M USDC against his ~2.79K MKR collateral, accounting for nearly 25% of the debt ceiling. The user’s current health score is 1.81.
+3. 0xf47841f562689ad85363b41c235d61136c0ccf26 - borrowing ~$801K USDC against his ~1.04K MKR collateral, accounting for nearly 9.5% of the debt ceiling. The user’s current health score is 1.79.
+4. 0x1e7267fa2628d66538822fc44f0edb62b07272a4 - borrowing ~$711K in stables (USDC and USDT) against his ~700 MKR collateral, accounting for nearly 8% of the debt ceiling. The user’s current health score is 1.59.
+
+## Specification
+
+| Asset | Parameter    | Current   | Recommendations |
+| ----- | ------------ | --------- | --------------- |
+| SNX   | Debt Ceiling | 2,500,000 | 4,000,000       |
+| MKR   | Debt Ceiling | 8,500,000 | 12,000,000      |
+
+## References
+
+- Implementation: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211.sol)
+- Tests: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211.t.sol)
+- [Snapshot](https://snapshot.org/#/aave.eth/proposal/0xe1a36b7daaf5ab8555510edf53fc75645c7a0ac26b3d47cfe9295b94f96bcf3a)
+- [Discussion](https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-debt-ceiling-for-snx-and-mkr-on-v3-ethereum-01-31-2024/16480/1)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211.s.sol
+++ b/src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211.s.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/GovV3Helpers.sol';
+import {EthereumScript} from 'aave-helpers/ScriptUtils.sol';
+import {AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211} from './AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * deploy-command: make deploy-ledger contract=src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211.s.sol:DeployEthereum chain=mainnet
+ * verify-command: npx catapulta-verify -b broadcast/ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211.s.sol/1/run-latest.json
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(
+        AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211
+      ).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](1);
+
+    // compose actions for validation
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
+    actionsEthereum[0] = GovV3Helpers.buildAction(
+      type(
+        AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024_20240211
+      ).creationCode
+    );
+    payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024.md'
+      )
+    );
+  }
+}

--- a/src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/config.ts
+++ b/src/20240211_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024/config.ts
@@ -1,0 +1,40 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV3Ethereum'],
+    title:
+      'Chaos Labs Risk Parameter Updates - Increase Debt Ceiling for SNX and MKR on V3 Ethereum - 01.31.2024',
+    shortName: 'ChaosLabsRiskParameterUpdatesIncreaseDebtCeilingForSNXAndMKROnV3Ethereum01312024',
+    date: '20240211',
+    author: 'Chaos Labs',
+    discussion:
+      'https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-debt-ceiling-for-snx-and-mkr-on-v3-ethereum-01-31-2024/16480/1',
+    snapshot:
+      'https://snapshot.org/#/aave.eth/proposal/0xe1a36b7daaf5ab8555510edf53fc75645c7a0ac26b3d47cfe9295b94f96bcf3a',
+  },
+  poolOptions: {
+    AaveV3Ethereum: {
+      configs: {
+        COLLATERALS_UPDATE: [
+          {
+            asset: 'MKR',
+            ltv: '',
+            liqThreshold: '',
+            liqBonus: '',
+            debtCeiling: '12_000_000',
+            liqProtocolFee: '',
+          },
+          {
+            asset: 'SNX',
+            ltv: '',
+            liqThreshold: '',
+            liqBonus: '',
+            debtCeiling: '4_000_000',
+            liqProtocolFee: '',
+          },
+        ],
+      },
+      cache: {blockNumber: 19204803},
+    },
+  },
+};


### PR DESCRIPTION
discussion - https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-debt-ceiling-for-snx-and-mkr-on-v3-ethereum-01-31-2024/16480
snapshot - https://snapshot.org/#/aave.eth/proposal/0xe1a36b7daaf5ab8555510edf53fc75645c7a0ac26b3d47cfe9295b94f96bcf3a